### PR TITLE
Fix HTML Entities error and new line character error

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "ejs": "^1.0.0",
     "lodash": "^2.4.1",
     "lodash.foreach": "^2.4.1",
-    "slackihook": "^1.0.0"
+    "slackihook": "^1.0.0",
+    "html-entities": "~1.2.0"
   },
   "strider": {
     "type": "job",


### PR DESCRIPTION
Fix error message send to slack when commit content HTML Entities or new line character.
With HTML Entities, you can see more at issues #13

